### PR TITLE
修复打开厨锅UI时的断言报错

### DIFF
--- a/rp/ui/cooking_pot.json
+++ b/rp/ui/cooking_pot.json
@@ -1149,10 +1149,10 @@
             }
          }
       ],
-      "default_control" : "default",
-      "hover_control" : "hover",
+      "default_control" : "",
+      "hover_control" : "",
       "is_handle_button_move_event" : true,
-      "pressed_control" : "pressed",
+      "pressed_control" : "",
       "size" : [ 18.0, 18.0 ],
       "sound_volume" : 0.0,
       "type" : "button"


### PR DESCRIPTION
1.controls里面找不到default，hover，pressed会有断言报错
![4d0e9fd07d57fc2f73364f950b0bb5c7](https://github.com/user-attachments/assets/db3f6d05-be28-4e1d-bf4d-005d211cd646)


PS.
另一个启动时的断言报错是由于netease:block_chest自带六面向，face_directional组件被添加了两次。不过似乎没法修，删掉face_directional就变成六面向了

![image](https://github.com/user-attachments/assets/a6139a74-89a6-43c5-afda-21f7af23e264)

